### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "tailwindcss": "^4.0.3",
     "vite-plugin-compression": "^0.5.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/server.js
+++ b/server.js
@@ -4,11 +4,21 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { createServer as createViteServer } from "vite";
 import devalue from "devalue"; // safely serialize JS objects to strings
+import rateLimit from "express-rate-limit";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function startServer() {
   const app = express();
+
+  // set up rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
+  // apply rate limiter to all requests
+  app.use(limiter);
 
   // 1) Create Vite in middleware mode
   const vite = await createViteServer({


### PR DESCRIPTION
Potential fix for [https://github.com/29Kumait/vue/security/code-scanning/2](https://github.com/29Kumait/vue/security/code-scanning/2)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library that can be used for this purpose. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes in the application.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to all routes using `app.use`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
