### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "vite-plugin-compression": "^0.5.1",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from "url";
 import { createServer as createViteServer } from "vite";
 import devalue from "devalue"; // safely serialize JS objects to strings
 import rateLimit from "express-rate-limit";
-
+import he from "he";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function startServer() {
@@ -75,7 +75,7 @@ async function startServer() {
     } catch (err) {
       vite.ssrFixStacktrace(err);
       console.error(err);
-      res.status(500).end(err.message);
+      res.status(500).end(he.escape(err.message));
     }
   });
 


### PR DESCRIPTION
Potential fix for [https://github.com/29Kumait/vue/security/code-scanning/1](https://github.com/29Kumait/vue/security/code-scanning/1)

To fix the problem, we need to ensure that the error message is properly escaped before being sent in the response. This can be achieved by using a library like `he` (HTML entities) to escape the error message. This will prevent any HTML or JavaScript code from being executed in the browser.

- Install the `he` library to handle HTML escaping.
- Modify the code to escape the error message before sending it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
